### PR TITLE
Removes Codecademy link from social link list

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -40,8 +40,6 @@
           <div class="list-group">
             <a href="https://www.linkedin.com/in/tyler-krys-5b06bb3/" class="list-group-item list-group-item-action" title="Tyler Krys - LinkedIn"><i class="fa fa-linkedin-square" aria-hidden="true"></i>
      &nbsp LinkedIn</a>
-            <a href="https://www.codecademy.com/ty2k" class="list-group-item list-group-item-action" title="Tyler Krys - Codecademy"><i class="fa fa-code" aria-hidden="true"></i>
-     &nbsp Codecademy</a>
             <a href="https://www.freecodecamp.com/ty2k" class="list-group-item list-group-item-action" title="Tyler Krys - freeCodeCamp"><i class="fa fa-free-code-camp" aria-hidden="true"></i>
      &nbsp freeCodeCamp</a>
             <a href="https://plus.google.com/u/0/+TylerKrys" class="list-group-item list-group-item-action" title="Tyler Krys - Google Plus"><i class="fa fa-google-plus-official" aria-hidden="true"></i>


### PR DESCRIPTION
Codecademy has no option for a public profile view unless the user is authenticated, so this update removes it from the social link list.